### PR TITLE
Ensure only scripts immediately in bin/ will be added to spec.executa…

### DIFF
--- a/sprite_work.gemspec
+++ b/sprite_work.gemspec
@@ -28,7 +28,9 @@ Gem::Specification.new do |spec|
   end
 
   spec.bindir = 'bin'
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{^bin/[^/]*$}) do |f|
+    File.basename(f)
+  end
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activemodel', '>= 4.0'


### PR DESCRIPTION
…bles

The nested, non-ruby scripts were causing errors when they were
accidentally being added to the spec.executables list. This grep
pattern will exclude any files located in directories nested in bin/.
