### PR TITLE
Replace dynamic gem executables logic with static whitelisting

### DIFF
--- a/sprite_work.gemspec
+++ b/sprite_work.gemspec
@@ -28,9 +28,8 @@ Gem::Specification.new do |spec|
   end
 
   spec.bindir = 'bin'
-  spec.executables = spec.files.grep(%r{^bin/[^/]*$}) do |f|
-    File.basename(f)
-  end
+  spec.executables = %w(console)
+
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activemodel', '>= 4.0'


### PR DESCRIPTION
All gem executables will have to be whitelisted inside of
sprite_work.gemspec for the time being. If the majority of bin/ is
non-ruby scripts, there's no point to having a dynamically defined
whitelisting.
